### PR TITLE
Add VM and CS notes for unsupported features

### DIFF
--- a/_includes/html-features-service-features.md
+++ b/_includes/html-features-service-features.md
@@ -19,9 +19,17 @@
 	<li class="list-group-item is-enabled">Node.js</li>
 	<li class="list-group-item is-enabled">PHP</li>
 	<li class="list-group-item is-enabled">Python</li>
-	<li class="list-group-item is-disabled">Remote Desktop Access</li>
-	<li class="list-group-item is-disabled">Reverse Proxy</li>
-	<li class="list-group-item is-disabled">Ruby</li>
+	<li class="list-group-item is-disabled">Remote Desktop Access 
+		<span class="label label-info">VM</span>
+		<span class="label label-info">CS</span>
+	</li>
+	<li class="list-group-item is-disabled">Reverse Proxy 
+		<span class="label label-info">VM</span>
+		<span class="label label-info">CS</span>
+	</li>
+	<li class="list-group-item is-disabled">Ruby 
+		<span class="label label-info">VM</span>
+	</li>
 	<li class="list-group-item is-enabled">Site Specific Configuration</li>
 	<li class="list-group-item is-enabled">SNI SSL</li>
 	<li class="list-group-item is-enabled">URL Rewrite</li>

--- a/_posts/01-01-01-Features-Service.md
+++ b/_posts/01-01-01-Features-Service.md
@@ -5,3 +5,5 @@ categories: [features]
 # Features
 
 {% include html-features-service-features.md %}
+
+Note: Features in gray are not available in Azure Websites. These features are available in Virtual Machines or Cloud Services as indicated by  <span class="label label-info">VM</span> for Virtual Machines and <span class="label label-info">CS</span> for Cloud Services. 


### PR DESCRIPTION
Added notes indicating Virtual Machine and Cloud Services coverage for features that aren't supported in Azure Websites.
